### PR TITLE
Allowed everyone to eject if nobody is in the drivers seat

### DIFF
--- a/source/Patches/VehicleController.cs
+++ b/source/Patches/VehicleController.cs
@@ -660,7 +660,7 @@ internal class VehicleControllerPatches
         var targetVehicle = (VehicleController)target;
 
         //don't process the rpc if the sender isn't the driver
-        if (rpcParams.Server.Receive.SenderClientId != targetVehicle.currentDriver.actualClientId) return false;
+        if (targetVehicle.currentDriver != null && rpcParams.Server.Receive.SenderClientId != targetVehicle.currentDriver.actualClientId) return false;
         return true;
     }
 


### PR DESCRIPTION
- Allowed everyone to eject if nobody is in the drivers seat (mainly to fix the below error)
```
NullReferenceException: Object reference not set to an instance of an object
  at CruiserImproved.Patches.VehicleControllerPatches.SpringDriverSeatServerRpc_Handler_Prefix (Unity.Netcode.NetworkBehaviour target, Unity.Netcode.FastBufferReader reader, Unity.Netcode.__RpcParams rpcParams) [0x0002f] in /home/runner/work/CruiserImproved/CruiserImproved/source/Patches/VehicleController.cs:663 
  at (wrapper dynamic-method) VehicleController.DMD<VehicleController::__rpc_handler_46143233>(Unity.Netcode.NetworkBehaviour,Unity.Netcode.FastBufferReader,Unity.Netcode.__RpcParams)
  at (wrapper delegate-invoke) <Module>.invoke_void_NetworkBehaviour_FastBufferReader___RpcParams(Unity.Netcode.NetworkBehaviour,Unity.Netcode.FastBufferReader,Unity.Netcode.__RpcParams)
  at Unity.Netcode.RpcMessageHelpers.Handle (Unity.Netcode.NetworkContext& context, Unity.Netcode.RpcMetadata& metadata, Unity.Netcode.FastBufferReader& payload, Unity.Netcode.__RpcParams& rpcParams) [0x0004e] in <895801699cfc4b4ab52267f31e2a4998>:0 
```