### PR TITLE
Updated the PlayerControllerB patch to only update camera position when in a vehicle.

### DIFF
--- a/source/Patches/PlayerController.cs
+++ b/source/Patches/PlayerController.cs
@@ -1,12 +1,4 @@
 ﻿using CruiserImproved.Network;
-using CruiserImproved.Utils;
-using GameNetcodeStuff;
-using HarmonyLib;
-using System.Collections.Generic;
-using System.Linq;
-using System.Reflection.Emit;
-using System.Reflection;
-using UnityEngine;
 
 namespace CruiserImproved.Patches;
 
@@ -22,22 +14,22 @@ internal class PlayerControllerPatches
         bool cameraSettingsEnabled = NetworkSync.Config.AllowLean || NetworkSync.Config.SeatBoostScale > 0f;
         if (!cameraSettingsEnabled) return;
 
-        Vector3 cameraOffset = Vector3.zero;
         if (__instance.inVehicleAnimation)
         {
+            Vector3 cameraOffset = Vector3.zero;
             //If we're in a car, boost the camera upward slightly for better visibility
             cameraOffset = new Vector3(0f, 0.25f, -0.05f) * NetworkSync.Config.SeatBoostScale;
             Vector3 lookFlat = __instance.gameplayCamera.transform.localRotation * Vector3.forward;
             lookFlat.y = 0;
             float angleToBack = Vector3.Angle(lookFlat, Vector3.back);
-            if(angleToBack < 70 && NetworkSync.Config.AllowLean)
+            if (angleToBack < 70 && NetworkSync.Config.AllowLean)
             {
                 //If we're looking backwards, offset the camera to the side ('leaning')
-                cameraOffset.x = Mathf.Sign(lookFlat.x) * ((70f - angleToBack)/70f);
+                cameraOffset.x = Mathf.Sign(lookFlat.x) * ((70f - angleToBack) / 70f);
             }
-        }
 
-        __instance.gameplayCamera.transform.localPosition = cameraOffset;
+            __instance.gameplayCamera.transform.localPosition = cameraOffset;
+        }
     }
 
     [HarmonyPatch("PlaceGrabbableObject")]

--- a/source/Patches/PlayerController.cs
+++ b/source/Patches/PlayerController.cs
@@ -1,4 +1,12 @@
 ﻿using CruiserImproved.Network;
+using CruiserImproved.Utils;
+using GameNetcodeStuff;
+using HarmonyLib;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection.Emit;
+using System.Reflection;
+using UnityEngine;
 
 namespace CruiserImproved.Patches;
 
@@ -22,10 +30,10 @@ internal class PlayerControllerPatches
             Vector3 lookFlat = __instance.gameplayCamera.transform.localRotation * Vector3.forward;
             lookFlat.y = 0;
             float angleToBack = Vector3.Angle(lookFlat, Vector3.back);
-            if (angleToBack < 70 && NetworkSync.Config.AllowLean)
+            if(angleToBack < 70 && NetworkSync.Config.AllowLean)
             {
                 //If we're looking backwards, offset the camera to the side ('leaning')
-                cameraOffset.x = Mathf.Sign(lookFlat.x) * ((70f - angleToBack) / 70f);
+                cameraOffset.x = Mathf.Sign(lookFlat.x) * ((70f - angleToBack)/70f);
             }
 
             __instance.gameplayCamera.transform.localPosition = cameraOffset;


### PR DESCRIPTION
## Purpose

Since this mod and [PlayerDogModel_Plus](https://github.com/wongnata/PlayerDogModel_Plus) both make changes to the camera position, this mod ends up overwriting the camera position changes for PlayerDogModel_Plus even when the player is not inside a vehicle.

I have a workaround for this issue which is updating these config values so that the camera position update is skipped:
- Allow Leaning = false
- Seat Boost Scale = 0

Obviously though it would be great to be able to use this mod to it's full potential with PlayerDogModel_Plus! Thanks for your help!

> [!WARNING]
>Please double-check these changes build and work fine for you! I was not able to build and deploy the project myself.

## Changes

- Updated the PlayerControllerB patch to only update camera position when in a vehicle.

## Issues fixed in this update
- [PlayerDogModel_Plus/issues/47](https://github.com/wongnata/PlayerDogModel_Plus/issues/47)