### PR TITLE
Consolidate VehicleID Checks and Fix VehicleCollisionTrigger errors.

### DIFF
--- a/source/Patches/GameNetworkManager.cs
+++ b/source/Patches/GameNetworkManager.cs
@@ -14,7 +14,7 @@ internal class GameNetworkManagerPatches
         //save cruiser data if we have one and it's vanilla
         try
         {
-            if (UserConfig.SaveCruiserValues.Value && StartOfRound.Instance.attachedVehicle && StartOfRound.Instance.attachedVehicle.vehicleID == 0)
+            if (UserConfig.SaveCruiserValues.Value && StartOfRound.Instance.attachedVehicle && PublicVehicleData.VehicleID == 0)
             {
                 VehicleController vehicle = StartOfRound.Instance.attachedVehicle;
                 SaveManager.Save("AttachedVehicleRotation", vehicle.magnetTargetRotation.eulerAngles);

--- a/source/Patches/PlayerController.cs
+++ b/source/Patches/PlayerController.cs
@@ -28,7 +28,7 @@ internal class PlayerControllerPatches
 
         //check we're in the vanilla Cruiser before modifying camera
         bool validCruiser = __instance.inVehicleAnimation && __instance.currentTriggerInAnimationWith && __instance.currentTriggerInAnimationWith.overridePlayerParent;
-        if (validCruiser && __instance.currentTriggerInAnimationWith.overridePlayerParent.TryGetComponent<VehicleController>(out var controller) && controller.vehicleID == 0)
+        if (validCruiser && __instance.currentTriggerInAnimationWith.overridePlayerParent.TryGetComponent<VehicleController>(out var controller) && PublicVehicleData.VehicleID == 0)
         {
             usingSeatCam = true;
             //If we're in a car, boost the camera upward slightly for better visibility

--- a/source/Patches/StartOfRound.cs
+++ b/source/Patches/StartOfRound.cs
@@ -86,7 +86,7 @@ internal class StartOfRoundPatches
     static void LoadAttachedVehicle_Postfix(StartOfRound __instance)
     {
         //Check for a saved vanilla Cruiser
-        if (!__instance.attachedVehicle || __instance.attachedVehicle.vehicleID != 0) return;
+        if (!__instance.attachedVehicle || PublicVehicleData.VehicleID != 0) return;
         try
         {
             var vehicle = __instance.attachedVehicle;

--- a/source/Patches/VehicleCollisionTrigger.cs
+++ b/source/Patches/VehicleCollisionTrigger.cs
@@ -12,6 +12,10 @@ internal class VehicleCollisionTriggerPatches
     [HarmonyPrefix]
     static bool OnTriggerEnter_Prefix(VehicleCollisionTrigger __instance, Collider other)
     {
+        if (PublicVehicleData.VehicleID != 0)
+        {
+            return true;
+        }
         if (!__instance.mainScript.hasBeenSpawned)
         {
             return true;

--- a/source/Patches/VehicleController.cs
+++ b/source/Patches/VehicleController.cs
@@ -13,6 +13,11 @@ using UnityEngine.AI;
 
 namespace CruiserImproved.Patches;
 
+public class PublicVehicleData
+{
+    public static int VehicleID;
+}
+
 [HarmonyPatch(typeof(VehicleController))]
 internal class VehicleControllerPatches
 {
@@ -70,6 +75,14 @@ internal class VehicleControllerPatches
 
     public static Dictionary<VehicleController, VehicleControllerData> vehicleData = new();
 
+    [HarmonyPatch("Awake")]
+    [HarmonyPostfix]
+    static void IDCheck(VehicleController __instance)
+    {
+        PublicVehicleData.VehicleID = __instance.vehicleID;
+        CruiserImproved.LogInfo("Setting Vehicle ID on Awake: " + PublicVehicleData.VehicleID);
+    }
+
     private static void RemoveStaleVehicleData()
     {
         List<VehicleController> vehiclesToRemove = new();
@@ -92,7 +105,7 @@ internal class VehicleControllerPatches
         VehicleControllerData thisData = vehicleData[vehicle];
 
         //don't modify non-vanilla cruiser
-        if (vehicle.vehicleID != 0) return;
+        if (PublicVehicleData.VehicleID != 0) return;
 
         //Allow player to turn further backward for the lean mechanic
         if (NetworkSync.Config.AllowLean)


### PR DESCRIPTION
Consolidates all checks for VehicleController's vehicleID to a public class/variable. Also fixes an issue where VehicleCollisionTrigger patches might be applying without checking for vehicleID, which could cause errors when colliding with enemies in a modded vehicle.