### PR TITLE
Maintenance, fixes for issues caused by v70+, tweaks & changes

### DIFF
--- a/source/Patches/GameNetworkManager.cs
+++ b/source/Patches/GameNetworkManager.cs
@@ -14,7 +14,7 @@ internal class GameNetworkManagerPatches
         //save cruiser data if we have one and it's vanilla
         try
         {
-            if (UserConfig.SaveCruiserValues.Value && StartOfRound.Instance.attachedVehicle && StartOfRound.Instance.attachedVehicle.vehicleID == 0)
+            if (UserConfig.SaveCruiserValues.Value && StartOfRound.Instance.attachedVehicle && PublicVehicleData.VehicleID == 0)
             {
                 VehicleController vehicle = StartOfRound.Instance.attachedVehicle;
                 SaveManager.Save("AttachedVehicleRotation", vehicle.magnetTargetRotation.eulerAngles);

--- a/source/Patches/GameNetworkManager.cs
+++ b/source/Patches/GameNetworkManager.cs
@@ -11,7 +11,7 @@ internal class GameNetworkManagerPatches
     [HarmonyPostfix]
     static void SaveItemsInShip_Postfix(GameNetworkManager __instance)
     {
-        //save cruiser data if we have one and it's vanilla
+        //save cruiser data, if we have one, and it's vanilla
         try
         {
             if (UserConfig.SaveCruiserValues.Value && StartOfRound.Instance.attachedVehicle && PublicVehicleData.VehicleID == 0)

--- a/source/Patches/PlayerController.cs
+++ b/source/Patches/PlayerController.cs
@@ -28,7 +28,7 @@ internal class PlayerControllerPatches
 
         //check we're in the vanilla Cruiser before modifying camera
         bool validCruiser = __instance.inVehicleAnimation && __instance.currentTriggerInAnimationWith && __instance.currentTriggerInAnimationWith.overridePlayerParent;
-        if (validCruiser && __instance.currentTriggerInAnimationWith.overridePlayerParent.TryGetComponent<VehicleController>(out var controller) && controller.vehicleID == 0)
+        if (validCruiser && __instance.currentTriggerInAnimationWith.overridePlayerParent.TryGetComponent<VehicleController>(out var controller) && PublicVehicleData.VehicleID == 0)
         {
             usingSeatCam = true;
             //If we're in a car, boost the camera upward slightly for better visibility

--- a/source/Patches/StartOfRound.cs
+++ b/source/Patches/StartOfRound.cs
@@ -86,7 +86,7 @@ internal class StartOfRoundPatches
     static void LoadAttachedVehicle_Postfix(StartOfRound __instance)
     {
         //Check for a saved vanilla Cruiser
-        if (!__instance.attachedVehicle || __instance.attachedVehicle.vehicleID != 0) return;
+        if (!__instance.attachedVehicle || PublicVehicleData.VehicleID != 0) return;
         try
         {
             var vehicle = __instance.attachedVehicle;

--- a/source/Patches/StartOfRound.cs
+++ b/source/Patches/StartOfRound.cs
@@ -6,8 +6,8 @@ using System.Reflection;
 using System.Reflection.Emit;
 using System;
 using CruiserImproved.Utils;
-
 using Random = UnityEngine.Random;
+using System.Collections;
 
 namespace CruiserImproved.Patches;
 

--- a/source/Patches/StartOfRound.cs
+++ b/source/Patches/StartOfRound.cs
@@ -22,7 +22,9 @@ internal class StartOfRoundPatches
         yield return null!;
         CruiserImproved.LogMessage($"Current frame: 2");
         yield return null!;
+        CruiserImproved.LogMessage($"Current frame: 3, waiting for end of frame");
         yield return new WaitForEndOfFrame();
+        CruiserImproved.LogMessage($"End of frame delay, attempting to set position of items");
         try
         {
             Item thisItem = StartOfRound.Instance.allItemsList.itemsList[itemArray[index]];

--- a/source/Patches/StartOfRound.cs
+++ b/source/Patches/StartOfRound.cs
@@ -18,8 +18,10 @@ internal class StartOfRoundPatches
 
     private static IEnumerator SetItemPositionAfterDelay(int index, Vector3[] positionArray, int[] itemArray)
     {
-        CruiserImproved.LogMessage($"Attempting to set item positions: {positionArray[index]}");
-        //wait until the end of the frame before setting item positions
+        CruiserImproved.LogMessage($"Current frame: 1");
+        yield return null!;
+        CruiserImproved.LogMessage($"Current frame: 2");
+        yield return null!;
         yield return new WaitForEndOfFrame();
         try
         {

--- a/source/Patches/StartOfRound.cs
+++ b/source/Patches/StartOfRound.cs
@@ -19,8 +19,8 @@ internal class StartOfRoundPatches
     private static IEnumerator SetItemPositionAfterDelay(int index, Vector3[] positionArray, int[] itemArray)
     {
         CruiserImproved.LogMessage($"Attempting to set item positions: {positionArray[index]}");
-        //wait two frames before setting item positions
-        yield return new WaitForSeconds(Time.deltaTime * 2);
+        //wait until the end of the frame before setting item positions
+        yield return new WaitForEndOfFrame();
         try
         {
             Item thisItem = StartOfRound.Instance.allItemsList.itemsList[itemArray[index]];

--- a/source/Patches/VehicleCollisionTrigger.cs
+++ b/source/Patches/VehicleCollisionTrigger.cs
@@ -12,6 +12,10 @@ internal class VehicleCollisionTriggerPatches
     [HarmonyPrefix]
     static bool OnTriggerEnter_Prefix(VehicleCollisionTrigger __instance, Collider other)
     {
+        if (PublicVehicleData.VehicleID != 0)
+        {
+            return true;
+        }
         if (!__instance.mainScript.hasBeenSpawned)
         {
             return true;

--- a/source/Patches/VehicleController.cs
+++ b/source/Patches/VehicleController.cs
@@ -360,6 +360,7 @@ internal class VehicleControllerPatches
             }
         }
 
+	//Don't modify non vanilla cruiser
 	if (PublicVehicleData.VehicleID == 0)
 	{
             //Fix items dropping through the back of the cruiser

--- a/source/Patches/VehicleController.cs
+++ b/source/Patches/VehicleController.cs
@@ -1012,16 +1012,21 @@ internal class VehicleControllerPatches
     [HarmonyPostfix]
     static void BreakWindshield_Postfix(VehicleController __instance)
     {
-        __instance.lod1Mesh.sharedMaterial = __instance.mainBodyMesh.sharedMaterial;
-        __instance.lod2Mesh.sharedMaterial = __instance.mainBodyMesh.sharedMaterial;
+        Material[] bodyMaterials = __instance.mainBodyMesh.sharedMaterials;
+        bodyMaterials[2] = __instance.windshieldBrokenMat;
+        __instance.lod1Mesh.sharedMaterials = bodyMaterials;
+        __instance.lod2Mesh.sharedMaterials = bodyMaterials;
     }
 
     [HarmonyPatch("SetHeadlightMaterial")]
     [HarmonyPostfix]
     static void SetHeadlightMaterial_Postfix(VehicleController __instance, bool on)
     {
-        __instance.lod1Mesh.sharedMaterial = __instance.mainBodyMesh.sharedMaterial;
-        __instance.lod2Mesh.sharedMaterial = __instance.mainBodyMesh.sharedMaterial;
+        Material headlightMat = on ? __instance.headlightsOnMat : __instance.headlightsOffMat;
+        Material[] bodyMaterials = __instance.mainBodyMesh.sharedMaterials;
+        bodyMaterials[1] = headlightMat;
+        __instance.lod1Mesh.sharedMaterials = bodyMaterials;
+        __instance.lod2Mesh.sharedMaterials = bodyMaterials;
     }
 
     //Patch non-drivers ejecting drivers in the Cruiser

--- a/source/Patches/VehicleController.cs
+++ b/source/Patches/VehicleController.cs
@@ -360,9 +360,12 @@ internal class VehicleControllerPatches
             }
         }
 
-        //Fix items dropping through the back of the cruiser
-        Transform itemDropCollider = __instance.physicsRegion.itemDropCollider.transform;
-        itemDropCollider.localScale = new Vector3(itemDropCollider.localScale.x, itemDropCollider.localScale.y, 5f);
+	if (PublicVehicleData.VehicleID == 0)
+	{
+            //Fix items dropping through the back of the cruiser
+            Transform itemDropCollider = __instance.physicsRegion.itemDropCollider.transform;
+            itemDropCollider.localScale = new Vector3(itemDropCollider.localScale.x, itemDropCollider.localScale.y, 5f);	
+	}
 
         if (NetworkSync.FinishedSync)
         {

--- a/source/Patches/VehicleController.cs
+++ b/source/Patches/VehicleController.cs
@@ -393,6 +393,13 @@ internal class VehicleControllerPatches
         //CruiserImproved.Log.LogMessage("Anti-slip force magnitude " + force.magnitude);
 
         __instance.mainRigidbody.AddForce(force, ForceMode.Acceleration);
+
+	if (!__instance.magnetedToShip)
+        {
+            return;
+        }
+        __instance.syncedPosition = __instance.transform.position;
+        __instance.syncedRotation = __instance.transform.rotation;
     }
 
     [HarmonyPatch("Update")]
@@ -969,6 +976,23 @@ internal class VehicleControllerPatches
         codes.Insert(index, new(OpCodes.Br, jumpTo));
 
         return codes;
+    }
+
+    //Fix materials (broken windshield, headlight on/off) not being applied to LODs
+    [HarmonyPatch("BreakWindshield")]
+    [HarmonyPostfix]
+    static void BreakWindshield_Postfix(VehicleController __instance)
+    {
+        __instance.lod1Mesh.sharedMaterial = __instance.mainBodyMesh.sharedMaterial;
+        __instance.lod2Mesh.sharedMaterial = __instance.mainBodyMesh.sharedMaterial;
+    }
+
+    [HarmonyPatch("SetHeadlightMaterial")]
+    [HarmonyPostfix]
+    static void SetHeadlightMaterial_Postfix(VehicleController __instance, bool on)
+    {
+        __instance.lod1Mesh.sharedMaterial = __instance.mainBodyMesh.sharedMaterial;
+        __instance.lod2Mesh.sharedMaterial = __instance.mainBodyMesh.sharedMaterial;
     }
 
     //Patch non-drivers ejecting drivers in the Cruiser

--- a/source/Patches/VehicleController.cs
+++ b/source/Patches/VehicleController.cs
@@ -1231,16 +1231,16 @@ internal class VehicleControllerPatches
             new(OpCodes.Call, fixMagnet),
             new(OpCodes.Stloc_1),
 
-            //return early if not owner
-            new(OpCodes.Ldarg_0),
-            new(OpCodes.Call, getIsOwner),
-            new(OpCodes.Brtrue, jumpLabel),
-            new(OpCodes.Ret),
-
             //return early if no localPlayerController yet to prevent a nullref when calling the rpc
             new(OpCodes.Call, PatchUtils.Method(typeof(GameNetworkManager), "get_Instance")),
             new(OpCodes.Ldfld, PatchUtils.Field(typeof(GameNetworkManager), "localPlayerController")),
             new(OpCodes.Call, typeof(UnityEngine.Object).GetMethod("op_Implicit")),
+            new(OpCodes.Brtrue, jumpLabel),
+            new(OpCodes.Ret),
+
+            //return early if not owner
+            new(OpCodes.Ldarg_0),
+            new(OpCodes.Call, getIsOwner),
             new(OpCodes.Brtrue, jumpLabel),
             new(OpCodes.Ret)
             ]);


### PR DESCRIPTION
    [Host] Tweaked sort equipment on load to run after a delay, to prevent items from floating out of bounds on reload [v70+]
    [Client] Fixed issue with certain materials (broken windshield, headlamp on/off material) not being applied to lower-level-of-detail models.
    [Client] Fixed issues with wheels not using the rotation of the corresponding collider, resulting in gimbal lock and unnatural behaviour.
    Moved a localPlayerController check on StartMagneting to before the isOwner check, should hopefully prevent a nullref error.
    Consolidated VehicleID checks & added one to vehicle collision trigger, to prevent modifying LLL vehicles.
    CruiserImproved is no longer compatible with LCVR, however this will be investigated.
